### PR TITLE
Add kernel dependency (Jammy)

### DIFF
--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -33,7 +33,9 @@ Standards-Version: 1.0.0
 
 Package: nvidia-imex-#BRANCH#
 Architecture: #ARCH_LIST#
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends:
+ nvidia-kernel-common-#BRANCH#-server (= ${binary:Version}),
+ ${misc:Depends}, ${shlibs:Depends}
 Provides: nvidia-imex
 Replaces: nvidia-imex
 Conflicts: nvidia-imex


### PR DESCRIPTION
Add a dependency between this package and
nvidia-kernel-common-#BRANCH#-server to keep the user space and kernel versions in sync.